### PR TITLE
chore: Edited .gitignore to match this project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,32 +1,5 @@
-# Prerequisites
-*.d
+# Directories - output from tools
+out
 
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
+# Directories - IDEs
+.idea


### PR DESCRIPTION
.gitignore was automatically generated for C++ project, this is
not required in this case and can be reduced for better readability
and maintenance.